### PR TITLE
MOST Documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@
    introduction/index.rst
    theory/index.rst
    user/index.rst
+   most/index.rst
    developer/index.rst
 
 

--- a/docs/most/NOTICE_MOST
+++ b/docs/most/NOTICE_MOST
@@ -1,0 +1,19 @@
+Copyright 2014 National Renewable Energy Laboratory and National 
+Technology & Engineering Solutions of Sandia, LLC (NTESS). 
+Under the terms of Contract DE-NA0003525 with NTESS, 
+the U.S. Government retains certain rights in this software.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+See full list of WEC-Sim Developers and Acknowledgements on the 
+WEC-Sim Website (http://wec-sim.github.io/WEC-Sim/master/index.html).

--- a/docs/most/acknowledgements.rst
+++ b/docs/most/acknowledgements.rst
@@ -1,0 +1,8 @@
+.. _most-acknowledgements:
+
+Acknowledgements
+================
+
+Funding
+-------
+Development and maintenance of the MOST software is funded by the ...

--- a/docs/most/advanced_features.rst
+++ b/docs/most/advanced_features.rst
@@ -1,0 +1,7 @@
+.. _most-advanced_features:
+
+Advanced Features
+=================
+
+TODO - describe the MOST example, how to change it, what the varies parameters mean, etc
+Mirror the WEC-Sim user manual/advanced features section

--- a/docs/most/index.rst
+++ b/docs/most/index.rst
@@ -1,0 +1,16 @@
+.. _most:
+
+###########
+MOST Manual
+###########
+
+.. toctree::
+   :maxdepth: 2 
+   
+   overview.rst
+   acknowledgements.rst
+   release_notes.rst
+   publications.rst
+   license.rst
+   theory.rst
+   advanced_features.rst

--- a/docs/most/license.rst
+++ b/docs/most/license.rst
@@ -1,0 +1,21 @@
+.. _most-license:
+
+License
+=======
+.. equivalent of this statement? "WEC-Sim is copyright through the National Renewable Energy Laboratory and National Technology & Engineering Solutions of Sandia, LLC (NTESS)"
+The software is distributed under the Apache License 2.0.
+
+
+Copyright 	
+------------
+
+.. literalinclude:: NOTICE_MOST
+   :language: text
+
+ 	
+Apache License 2.0
+-------------------------
+
+.. literalinclude:: ../../LICENSE
+   :language: text
+

--- a/docs/most/overview.rst
+++ b/docs/most/overview.rst
@@ -1,0 +1,29 @@
+.. _most-overview:
+
+Overview
+========
+
+MOST is an open-source software that simulates the behavior of an Offshore Floating Wind Turbine (OFWT) in specific weather conditions.
+MOST builds on WEC-Sim in MATLAB/Simulink to add a ``windClass`` and ``windTurbineClass` objects that can define a given turbine and weather conditions.
+Currently, MOST supports single-tower, three-bladed, horizontal axis wind turbines defined by mass properties, aerodynamic loading and a ROSCO controller.
+
+
+.. _most-developers:
+
+MOST Developers
+---------------
+MOST is developed and maintained by the MORE Energy Lab, Politecnico di Torino, Italy.
+The WEC-Sim+MOST coupling is a collaboration between the MORE Energy Lab and the WEC-Sim developers at Sandia National Laboratories and the National Renewable Energy Lab. 
+
+Current members of the MOST development team include:
+
+* Giovanni Bracco (PI)
+* Emilio Faraggiana
+* Alberto Ghigo
+* Ermando Petracca
+* Massimo Sirigu
+
+.. TODO - list former MOST developers as appropriate
+
+
+

--- a/docs/most/publications.rst
+++ b/docs/most/publications.rst
@@ -1,0 +1,6 @@
+.. _most-publications:
+
+Publications
+============
+
+TODO - enter any MOST theses, publications here. This is a historical list, whereas the release_notes only contains the most recent citation

--- a/docs/most/release_notes.rst
+++ b/docs/most/release_notes.rst
@@ -1,0 +1,50 @@
+.. _most-release-notes:
+
+Release Notes
+=============
+
+.. _most-citation:
+
+
+`MOST v1.0.0 (within WEC-Sim v5.1) <https://github.com/WEC-Sim/WEC-Sim/releases/tag/v5.0.1>`_
+--------------------------------------------------------------------------------------
+
+**New Features**
+
+* Addition of the windClass object
+
+* Addition of the windTurbineClass object
+
+* Addition of the MOST library
+
+* Release of an WEC-Sim+MOST Application
+
+
+Citing MOST
+------------------------
+
+When using MOST with WEC-Sim, please cite the following MOST publication in addition to the WEC-Sim software release and publication:
+
+.. TODO - add publication that users should cite when using MOST
+
+.. TODO - add latex format for easy reference
+.. code-block:: none
+
+	@software{wecsim,
+	  author       = {Kelley Ruehl, 
+                      David Ogden, 
+                      Yi-Hsiang Yu, 
+                      Adam Keester, 
+                      Nathan Tom, 
+                      Dominic Forbush, 
+                      Jorge Leon, 
+                      Jeff Grasberger, 
+                      Salman Husain},
+	  title        = {WEC-Sim v5.0.1},
+	  month        = September,
+	  year         = 2022,
+	  publisher    = {Zenodo},
+	  version      = {v5.0.1},
+	  doi          = {10.5281/zenodo.7121186},
+	  url          = {https://zenodo.org/badge/latestdoi/20451353}
+	}

--- a/docs/most/theory.rst
+++ b/docs/most/theory.rst
@@ -1,0 +1,23 @@
+.. _most-theory:
+
+Theory
+======
+
+.. _most-theory-wind:
+
+Wind Conditions
+---------------
+
+
+.. _most-theory-aero:
+
+Aerodynamic Loading
+-------------------
+
+
+.. _most-theory-rosco:
+
+ROSCO Controller
+----------------
+
+


### PR DESCRIPTION
This PR adds a basic outline of a "MOST Manual" that will build automatically with the WEC-Sim documentation. I pulled some information from the previous MOST manual, but I thought that was based on the previous version of MOST. We could probably set-up a method to automatically convert this into a PDF for your use and advertisement as well.

Please review the outline and add/remove sections as appropriate. After merging this initial set-up, I could use help from the MOST team in completing the following information:
- [x] Add any publications and the desired citation for users utilizing MOST
- [x] Any license/copyright information
- [x] list of MOST developers (current and/or former)
- [x] funding acknowledgement
- [x] theory section detailing the equations of motion, how to define and the impact of the wind inputs, wind turbine aerodynamic loading, ROSCO controller, etc
- [x] advanced feature section describing the windClass and windTurbineClass parameters and how they should be used