### PR TITLE
Refactoring for the windTurbineClass and MOST library

### DIFF
--- a/source/functions/MOST/readTurbSimOutput.m
+++ b/source/functions/MOST/readTurbSimOutput.m
@@ -1,0 +1,30 @@
+function readTurbSimOutput(filename)
+% Reads data from a TurbSim output file and writes a table for the
+% windTurbineClass to import
+% 
+% See ``WEC-Sim-Applications/MOST/mostIO.m`` for examples of usage.
+% 
+% Parameters
+% ----------
+%     obj : filename
+%         Path to the TurbSim output file (*.bts)
+% 
+% See readfile_BTS for description of the returned parameters
+%
+
+% Read TurbSim file
+[velocity, twrVelocity, y, z, zTwr, nz, ny, dz, dy, dt, zHub, z1, mffws] = readfile_BTS([filename '.bts']);
+
+% Select relevant variables
+tmp = squeeze(velocity(:,1,:,:));
+wind.velocity = flip(tmp,2);
+wind.time = (0:size(wind.velocity,1)-1)*dt;
+wind.yDiscr = y;
+wind.zDiscr = z;
+wind.hubHeight = zHub;
+wind.meanVelocity = mffws;
+
+% Save to an intermediate file
+save([filename '.mat'],"wind");
+
+end

--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -210,8 +210,10 @@ if exist('ptoSim','var') == 1
 end
 
 % WindClass
-if wind.constantWindFlag == 0
-    wind.importTurbSimOutput();
+if exist('windTurbine','var') == 1
+    if wind.constantWindFlag == 0
+        wind.importTurbSimOutput();
+    end
 end
 
 % WindturbineClass
@@ -432,17 +434,19 @@ try
     end; clear ii;
 end
 
-% wind turbine
-for ii=1:length(windTurbine)
-    eval(['ControlChoice' num2str(ii) ' = windTurbine(',num2str(ii),').control;'])
-    eval(['sv_' num2str(ii) '_control1 = Simulink.Variant(''ControlChoice' num2str(ii) '==0'');'])
-    eval(['sv_' num2str(ii) '_control2 = Simulink.Variant(''ControlChoice' num2str(ii) '==1'');'])  
-end; clear ii
+try
+    % wind turbine
+    for ii=1:length(windTurbine)
+        eval(['ControlChoice' num2str(ii) ' = windTurbine(',num2str(ii),').control;'])
+        eval(['sv_' num2str(ii) '_control1 = Simulink.Variant(''ControlChoice' num2str(ii) '==0'');'])
+        eval(['sv_' num2str(ii) '_control2 = Simulink.Variant(''ControlChoice' num2str(ii) '==1'');'])  
+    end; clear ii
 
-% wind 
-eval(['WindChoice = wind.constantWindFlag;'])
-eval(['sv_wind_constant = Simulink.Variant(''WindChoice==1'');'])
-eval(['sv_wind_turbulent = Simulink.Variant(''WindChoice==0'');'])
+    % wind 
+    eval(['WindChoice = wind.constantWindFlag;'])
+    eval(['sv_wind_constant = Simulink.Variant(''WindChoice==1'');'])
+    eval(['sv_wind_turbulent = Simulink.Variant(''WindChoice==0'');'])
+end
 
 % Visualization Blocks
 if ~isempty(waves.marker.location) && typeNum < 30

--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -5,9 +5,9 @@
 %%
 %% simu = simulationClass();                                               - To Create the Simulation Variable
 %%
-%% waves = waveClass('<wave type');                                       - To create the Wave Variable and Specify Type
+%% waves = waveClass('<wave type>');                                       - To create the Wave Variable and Specify Type
 %%
-%% body(<body number>) = bodyClass('<hydrodynamics data file name>.h5');   - To initialize bodyClass:
+%% body(<body number>) = bodyClass('<hydrodynamics data file name>.h5');   - To initialize bodyClass
 %%
 %% constraint(<constraint number>) = constraintClass('<Constraint name>'); - To initialize constraintClass
 %%
@@ -15,6 +15,9 @@
 %%
 %% mooring(<mooring number>) = mooringClass('<Mooring name>');             - To initialize mooringClass (only needed when mooring blocks are used)
 %%
+%% wind = windClass('<wind type>');                                        - To create the wind variable and specify type, for WEC-Sim+MOST
+%%
+%% windTurbine(<turbine number>) = windTurbineClass('<Wind turbine name>');- To initialize windTurbineClass, for WEC-Sim+MOST
 %%
 
 %% Start WEC-Sim log
@@ -209,14 +212,14 @@ if exist('ptoSim','var') == 1
     end; clear ii
 end
 
-% WindClass
+% Wind: check inputs
 if exist('wind','var') == 1
     if wind.constantWindFlag == 0
         wind.importTurbSimOutput();
     end
 end
 
-% WindturbineClass
+% Wind turbines: count, check inputs, import controller
 if exist('windTurbine','var') == 1
     for ii = 1:length(windTurbine)
         windTurbine(ii).importAeroLoadsTable()
@@ -443,9 +446,9 @@ try
     end; clear ii
 
     % wind 
-    eval(['WindChoice = wind.constantWindFlag;'])
-    eval(['sv_wind_constant = Simulink.Variant(''WindChoice==1'');'])
-    eval(['sv_wind_turbulent = Simulink.Variant(''WindChoice==0'');'])
+    WindChoice = wind.constantWindFlag;
+    sv_wind_constant = Simulink.Variant('WindChoice==1');
+    sv_wind_turbulent = Simulink.Variant('WindChoice==0');
 end
 
 % Visualization Blocks

--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -210,7 +210,7 @@ if exist('ptoSim','var') == 1
 end
 
 % WindClass
-if exist('windTurbine','var') == 1
+if exist('wind','var') == 1
     if wind.constantWindFlag == 0
         wind.importTurbSimOutput();
     end
@@ -219,11 +219,11 @@ end
 % WindturbineClass
 if exist('windTurbine','var') == 1
     for ii = 1:length(windTurbine)
-        windTurbine(ii).ImportAeroloadsTable
-        windTurbine(ii).loadTurbineData
+        windTurbine(ii).importAeroLoadsTable()
+        windTurbine(ii).loadTurbineData()
         windTurbine(ii).setNumber(ii);
         if windTurbine(ii).control == 1
-            windTurbine(ii).Importrosco
+            windTurbine(ii).importROSCO()
         end
     end 
     clear ii

--- a/source/functions/initializeWecSim.m
+++ b/source/functions/initializeWecSim.m
@@ -215,13 +215,13 @@ if wind.constantWindFlag == 0
 end
 
 % WindturbineClass
-if exist('windturbine','var') == 1
-    for ii = 1:length(windturbine)
-        windturbine(ii).ImportAeroloadsTable
-        windturbine(ii).loadTurbineData
-        windturbine(ii).setNumber(ii);
-        if windturbine(ii).control == 1
-            windturbine(ii).Importrosco
+if exist('windTurbine','var') == 1
+    for ii = 1:length(windTurbine)
+        windTurbine(ii).ImportAeroloadsTable
+        windTurbine(ii).loadTurbineData
+        windTurbine(ii).setNumber(ii);
+        if windTurbine(ii).control == 1
+            windTurbine(ii).Importrosco
         end
     end 
     clear ii
@@ -433,8 +433,8 @@ try
 end
 
 % wind turbine
-for ii=1:length(windturbine)
-    eval(['ControlChoice' num2str(ii) ' = windturbine(',num2str(ii),').control;'])
+for ii=1:length(windTurbine)
+    eval(['ControlChoice' num2str(ii) ' = windTurbine(',num2str(ii),').control;'])
     eval(['sv_' num2str(ii) '_control1 = Simulink.Variant(''ControlChoice' num2str(ii) '==0'');'])
     eval(['sv_' num2str(ii) '_control2 = Simulink.Variant(''ControlChoice' num2str(ii) '==1'');'])  
 end; clear ii

--- a/source/functions/postProcessWecSim.m
+++ b/source/functions/postProcessWecSim.m
@@ -9,11 +9,11 @@ clear clock_out
 
 % Wind Turbine
 
-if exist('windturbine','var')
-    for iTurb = 1:length(windturbine)
-        windturbineOutput(iTurb) = eval(['windturbine' num2str(iTurb) '_out']);
-        windturbineOutput(iTurb).name = windturbine(iTurb).name;
-        eval(['clear windturbine' num2str(iTurb) '_out'])
+if exist('windTurbine','var')
+    for iTurb = 1:length(windTurbine)
+        windTurbineOutput(iTurb) = eval(['windTurbine' num2str(iTurb) '_out']);
+        windTurbineOutput(iTurb).name = windTurbine(iTurb).name;
+        eval(['clear windTurbine' num2str(iTurb) '_out'])
     end; clear iTurb
 end
 
@@ -120,8 +120,8 @@ waveOutput.type = waves.type;
 waveOutput.waveAmpTime = waves.waveAmpTime;
 
 % All
-output = responseClass(bodiesOutput,ptosOutput,constraintsOutput,ptosimOutput,cablesOutput,mooringOutput,waveOutput,windturbineOutput);
-clear bodiesOutput ptosOutput constraintsOutput ptosimOutput cablesOutput mooringOutput waveOutput windturbineOutput
+output = responseClass(bodiesOutput,ptosOutput,constraintsOutput,ptosimOutput,cablesOutput,mooringOutput,waveOutput,windTurbineOutput);
+clear bodiesOutput ptosOutput constraintsOutput ptosimOutput cablesOutput mooringOutput waveOutput windTurbineOutput
 
 
 % MoorDyn

--- a/source/functions/postProcessWecSim.m
+++ b/source/functions/postProcessWecSim.m
@@ -7,16 +7,6 @@ fprintf('\nPost-processing and saving...   \n')
 simu.time = clock_out.time;
 clear clock_out
 
-% Wind Turbine
-
-if exist('windTurbine','var')
-    for iTurb = 1:length(windTurbine)
-        windTurbineOutput(iTurb) = eval(['windTurbine' num2str(iTurb) '_out']);
-        windTurbineOutput(iTurb).name = windTurbine(iTurb).name;
-        eval(['clear windTurbine' num2str(iTurb) '_out'])
-    end; clear iTurb
-end
-
 % Bodies
 for iBod = 1:length(body(1,:))
     eval(['body' num2str(iBod) '_out.name = body(' num2str(iBod) ').name;']);    
@@ -119,10 +109,20 @@ waveOutput = struct();
 waveOutput.type = waves.type;
 waveOutput.waveAmpTime = waves.waveAmpTime;
 
+% Wind Turbine
+if exist('windTurbine','var')
+    for iTurb = 1:length(windTurbine)
+        windTurbineOutput(iTurb) = eval(['windTurbine' num2str(iTurb) '_out']);
+        windTurbineOutput(iTurb).name = windTurbine(iTurb).name;
+        eval(['clear windTurbine' num2str(iTurb) '_out'])
+    end; clear iTurb
+else
+    windTurbineOutput = 0;
+end
+
 % All
 output = responseClass(bodiesOutput,ptosOutput,constraintsOutput,ptosimOutput,cablesOutput,mooringOutput,waveOutput,windTurbineOutput);
 clear bodiesOutput ptosOutput constraintsOutput ptosimOutput cablesOutput mooringOutput waveOutput windTurbineOutput
-
 
 % MoorDyn
 for iMoor = 1:simu.numMoorings

--- a/source/functions/stopWecSim.m
+++ b/source/functions/stopWecSim.m
@@ -20,6 +20,7 @@ toc
 tic
 %% Post processing and Saving Results
 postProcessWecSim
+
 % User Defined Post-Processing
 if exist('userDefinedFunctions.m','file') == 2
     userDefinedFunctions;
@@ -57,9 +58,7 @@ if simu.saveWorkspace==1
     end
 end
 
-%% Remove 'temp' directory
-
-% Remove 'temp' directory from path and remove 'temp' directory
+%% Remove 'temp' directory from path and remove 'temp' directory
 rmpath(fullfile(projectRootDir,'temp'));
 try
     rmdir(fullfile(projectRootDir,'temp'),'s');

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -200,14 +200,16 @@ classdef responseClass<handle
                     end
                 end
             end
-            % Wind turbine
-            signals = {'WindSpeed','TurbinePower','RotorSpeed','BladePitch','NacAcceleration','TowerBaseLoad','TowerTopLoad','BladeRootLoad','GenTorque','Azimuth'};
-            outputDim = [1 1 1 1 1 6 6 6 1 1];
-            for ii = 1:length(windTurbineOutput)
-                obj.windTurbine(ii).name = windTurbineOutput(ii).name;
-                obj.windTurbine(ii).time = windTurbineOutput(ii).time;
-                for jj = 1:length(signals)
-                    obj.windTurbine(ii).(signals{jj}) = windTurbineOutput(ii).signals.values(:, sum(outputDim(1:jj-1))+1:sum(outputDim(1:jj-1))+outputDim(jj));
+            if isstruct(windTurbineOutput)
+                % Wind turbine
+                signals = {'WindSpeed','TurbinePower','RotorSpeed','BladePitch','NacAcceleration','TowerBaseLoad','TowerTopLoad','BladeRootLoad','GenTorque','Azimuth'};
+                outputDim = [1 1 1 1 1 6 6 6 1 1];
+                for ii = 1:length(windTurbineOutput)
+                    obj.windTurbine(ii).name = windTurbineOutput(ii).name;
+                    obj.windTurbine(ii).time = windTurbineOutput(ii).time;
+                    for jj = 1:length(signals)
+                        obj.windTurbine(ii).(signals{jj}) = windTurbineOutput(ii).signals.values(:, sum(outputDim(1:jj-1))+1:sum(outputDim(1:jj-1))+outputDim(jj));
+                    end
                 end
             end
             % Constraints

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -117,8 +117,22 @@ classdef responseClass<handle
     %   * ``pmLinearGenerator`` (`struct`) = [1 x # of generators] Structure containing timeseries of permanent magnet linear generator properties including absolute power, force, friction force, current, voltage, velocity and electrical power
     %   * ``pmRotaryGenerator`` (`struct`) = [1 x # of generators] Structure containing timeseries of permanent magnet rotary generator properties including absolute power, force, friction force, current, voltage, velocity and electrical power 
     %   * ``motionMechanism`` (`struct`) = [1 x # of mechanisms] Structure containing timeseries of motion mechanism properties including PTO torque, angular position and angular velocity
+    %
+    % .. autoattribute:: objects.responseClass.windTurbine
+    %    
+    %   * ``name`` (`string`) = 'windTurbineName'
+    %   * ``time`` (`array`) = [# of time-steps x 1]
+    %   * ``windSpeed`` (`array`) = [# of time-steps x 1]
+    %   * ``turbinePower`` (`array`) = [# of time-steps x 1]
+    %   * ``rotorSpeed`` (`array`) = [# of time-steps x 1]
+    %   * ``bladePitch`` (`array`) = [# of time-steps x 1] Pitch position of blade 1
+    %   * ``nacelleAcceleration`` (`array`) = [# of time-steps x 1]
+    %   * ``towerBaseLoad`` (`array`) = [# of time-steps x 6] 6DOF force at the constraint between the floating body and tower base
+    %   * ``towerTopLoad`` (`array`) = [# of time-steps x 6] 6DOF force at the constraint between the tower base and tower nacelle 
+    %   * ``bladeRootLoad`` (`array`) = [# of time-steps x 1] 6DOF force at the constraint between blade 1 and the hub 
+    %   * ``genTorque`` (`array`) = [# of time-steps x 1] Torque on the generator
+    %   * ``azimuth`` (`array`) = [# of time-steps x 1] azimuthal angle of the generator 
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    
     
     properties (SetAccess = 'public', GetAccess = 'public')
         bodies              = struct()     % This property contains a structure for each instance of the ``bodyClass`` (i.e. for each Body block)
@@ -137,7 +151,7 @@ classdef responseClass<handle
             % This method initializes the ``responseClass``, reads 
             % output from each instance of a WEC-Sim class (e.g.
             % ``waveClass``, ``bodyClass``, ``ptoClass``, ``mooringClass``, etc)
-            % , and saves the response to an ``output`` object. 
+            % and saves the response to an ``output`` object. 
             %
             % Returns
             % ------------
@@ -189,6 +203,7 @@ classdef responseClass<handle
                     obj.bodies(ii).cellPressures_waveNonLinear = [];
                 end
             end
+            
             % PTOs
             if isstruct(ptosOutput)
                 signals = {'position','velocity','acceleration','forceTotal','forceActuation','forceConstraint','forceInternalMechanics','powerInternalMechanics'};
@@ -200,9 +215,10 @@ classdef responseClass<handle
                     end
                 end
             end
+
             if isstruct(windTurbineOutput)
                 % Wind turbine
-                signals = {'WindSpeed','TurbinePower','RotorSpeed','BladePitch','NacAcceleration','TowerBaseLoad','TowerTopLoad','BladeRootLoad','GenTorque','Azimuth'};
+                signals = {'windSpeed','turbinePower','rotorSpeed','bladePitch','nacelleAcceleration','towerBaseLoad','towerTopLoad','bladeRootLoad','genTorque','azimuth'};
                 outputDim = [1 1 1 1 1 6 6 6 1 1];
                 for ii = 1:length(windTurbineOutput)
                     obj.windTurbine(ii).name = windTurbineOutput(ii).name;
@@ -212,6 +228,7 @@ classdef responseClass<handle
                     end
                 end
             end
+
             % Constraints
             if isstruct(constraintsOutput)
                 signals = {'position','velocity','acceleration','forceConstraint'}; 
@@ -223,6 +240,7 @@ classdef responseClass<handle
                     end
                 end
             end
+
             % Mooring
             if isstruct(mooringOutput)
                 signals = {'position','velocity','forceMooring'}; 
@@ -234,6 +252,7 @@ classdef responseClass<handle
                     end
                 end
             end
+
             % Cables
             if isstruct(cablesOutput)
                 signals = {'position','velocity','acceleration','forceTotal','forceActuation',...
@@ -246,6 +265,7 @@ classdef responseClass<handle
                     end
                 end
             end
+
             % PTO-Sim
             if isstruct(ptosimOutput)
                 hydPistonCompressibleSignals = {'pressureA','forcePTO','pressureB'};

--- a/source/objects/responseClass.m
+++ b/source/objects/responseClass.m
@@ -129,11 +129,11 @@ classdef responseClass<handle
         ptos                = struct()     % This property contains a structure for each instance of the ``ptoClass`` (i.e. for each PTO block). PTO motion is relative from frame F to frame B. PTO forces act on frame F.
         ptoSim              = struct()     % This property contains a structure for each instance of the ``ptoSimClass`` (i.e. for each PTO-Sim block).
         wave                = struct()     % This property contains a structure for each instance of the ``waveClass``         
-        windturbine         = struct()     % This property contains a structure for each instance of the ``windTurbineClass``     
+        windTurbine         = struct()     % This property contains a structure for each instance of the ``windTurbineClass``     
     end
     
     methods (Access = 'public')
-        function obj = responseClass(bodiesOutput,ptosOutput,constraintsOutput,ptosimOutput,cablesOutput,mooringOutput,waveOutput,windturbineOutput) 
+        function obj = responseClass(bodiesOutput,ptosOutput,constraintsOutput,ptosimOutput,cablesOutput,mooringOutput,waveOutput,windTurbineOutput) 
             % This method initializes the ``responseClass``, reads 
             % output from each instance of a WEC-Sim class (e.g.
             % ``waveClass``, ``bodyClass``, ``ptoClass``, ``mooringClass``, etc)
@@ -203,11 +203,11 @@ classdef responseClass<handle
             % Wind turbine
             signals = {'WindSpeed','TurbinePower','RotorSpeed','BladePitch','NacAcceleration','TowerBaseLoad','TowerTopLoad','BladeRootLoad','GenTorque','Azimuth'};
             outputDim = [1 1 1 1 1 6 6 6 1 1];
-            for ii = 1:length(windturbineOutput)
-                obj.windturbine(ii).name = windturbineOutput(ii).name;
-                obj.windturbine(ii).time = windturbineOutput(ii).time;
+            for ii = 1:length(windTurbineOutput)
+                obj.windTurbine(ii).name = windTurbineOutput(ii).name;
+                obj.windTurbine(ii).time = windTurbineOutput(ii).time;
                 for jj = 1:length(signals)
-                    obj.windturbine(ii).(signals{jj}) = windturbineOutput(ii).signals.values(:, sum(outputDim(1:jj-1))+1:sum(outputDim(1:jj-1))+outputDim(jj));
+                    obj.windTurbine(ii).(signals{jj}) = windTurbineOutput(ii).signals.values(:, sum(outputDim(1:jj-1))+1:sum(outputDim(1:jj-1))+outputDim(jj));
                 end
             end
             % Constraints

--- a/source/objects/windClass.m
+++ b/source/objects/windClass.m
@@ -29,6 +29,7 @@ classdef windClass<handle
     properties (SetAccess = 'public', GetAccess = 'public') % input file
         turbSimFile = '';                         % Wind table of turbulent wind from Turbsim.           
         meanVelocity = [];                        % Mean hub height wind speed. Defined in the input file for constant wind conditions, by TurbSim output for turbulent conditions
+        hubYLoc
     end
 
     properties (SetAccess = 'private', GetAccess = 'public')

--- a/source/objects/windClass.m
+++ b/source/objects/windClass.m
@@ -27,7 +27,7 @@ classdef windClass<handle
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
     properties (SetAccess = 'public', GetAccess = 'public') % input file
-        turbSimFile = '';                         % Wind table of turbulent wind from Turbsim.           
+        turbSimFile = '';                         % Table of turbulent wind data from TurbSim.
         meanVelocity = [];                        % Mean hub height wind speed. Defined in the input file for constant wind conditions, by TurbSim output for turbulent conditions
         hubYLoc
     end
@@ -59,7 +59,7 @@ classdef windClass<handle
             %
             obj.type = type;
             switch obj.type
-                case {'constant'}         % Constant wind conditions, no TurbSim input
+                case {'constant'}          % Constant wind conditions, no TurbSim input
                     obj.constantWindFlag = 1;
                 case {'turbulent'}         % Turbulent wind conditions, determined by TurbSim input
                     obj.constantWindFlag = 0;
@@ -69,26 +69,23 @@ classdef windClass<handle
         end
 
         function obj = importTurbSimOutput(obj)
-            % Reads data from a TurbSim output file and writes a table for the
-            % windTurbineClass.
+            % Loads TurbSim data from an intermediate file created by
+            % readTurbSimOutput
             % 
-            % See ``WEC-Sim-Applications/MOST/TurbSim/tsio.m`` for examples of usage.
+            % See ``WEC-Sim-Applications/MOST/mostIO.m`` for examples of usage.
             % 
             % Parameters
             % ----------
             %     obj : windClass
             %         windClass object
             % 
-            
-            % See readfile_BTS for description of the returned parameters
-            [velocity, twrVelocity, y, z, zTwr, nz, ny, dz, dy, dt, zHub, z1, mffws] = readfile_BTS(obj.turbSimFile);
-            tmp = squeeze(velocity(:,1,:,:));
-            obj.velocity = flip(tmp,2);
-            obj.time = (0:size(obj.velocity,1)-1)*dt;
-            obj.yDiscr = y;
-            obj.zDiscr = z;
-            obj.hubHeight = zHub;
-            obj.meanVelocity = mffws;
+            data = importdata(obj.turbSimFile);
+            obj.velocity = data.velocity;
+            obj.time = data.time;
+            obj.yDiscr = data.yDiscr;
+            obj.zDiscr = data.zDiscr;
+            obj.hubHeight = data.hubHeight;
+            obj.meanVelocity = data.meanVelocity;
          end
 
      end

--- a/source/objects/windTurbineClass.m
+++ b/source/objects/windTurbineClass.m
@@ -25,7 +25,7 @@ classdef windTurbineClass<handle
     properties (SetAccess = 'public', GetAccess = 'public') %input file
         name              = []                               % (`string`) Specifies the windTurbine name. 
         control = 0;                                         % Type of control: 0-->baseline, 1-->ROSCO   
-        aeroloadsName = '';                                  % Name of aeroloads file       
+        aeroLoadsName = '';                                  % Name of aeroloads file       
         turbineName = '';                                    % Name of file including wind turbine properties  
         roscoName = '';                                      % Name of file for ROSCO properties
         omega0 = [];                                         % Initial rotor speed
@@ -35,9 +35,8 @@ classdef windTurbineClass<handle
         geometryFileBlade = '';                              % Blade geometry file
     end
     
-    
     properties (SetAccess = 'private', GetAccess = 'public')
-        aeroloads = struct(...                               % Rotor loads structure
+        aeroLoads = struct(...                               % Rotor loads structure
             'FX',     0, ...                                 % Thrust forces look-up table
             'FY',             [0 0 0], ...                   % Tangential forces look-up table
             'MX',      [0 0 0], ...                          % Torque look-up table
@@ -68,7 +67,7 @@ classdef windTurbineClass<handle
             'inertiaProducts',      [0 0 0], ...             % Product of inertia of hub
             'reference',           [0 0 0], ...              % Hub reference point for blades
             'precone',           [0 0 0], ...                % Hub precone angle (deg)
-            'hubheight',           [0 0 0], ...              % Hub height relative to Sea Water Level
+            'height',              [0 0 0], ...              % Hub height relative to Sea Water Level
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to nacelle reference
         blade = struct(...                                   % Blade structure properties
             'mass',     0, ...                               % Mass of the blade 
@@ -102,19 +101,19 @@ classdef windTurbineClass<handle
             end
         end
 
-         function ImportAeroloadsTable(obj)
-            data = importdata(obj.aeroloadsName);
-            obj.aeroloads = data;
+         function importAeroLoadsTable(obj)
+            data = importdata(obj.aeroLoadsName);
+            obj.aeroLoads = data;
          end
 
-         function Importrosco(obj)
+         function importROSCO(obj)
             data = importdata(obj.roscoName);
             obj.ROSCO = data;
          end
 
          function loadTurbineData(obj)
             data = importdata(obj.turbineName); 
-            obj.generatorEfficiency=data.gen_eff; %generator efficiency
+            obj.generatorEfficiency = data.gen_eff; %generator efficiency
             obj.geometryFileTower = data.geometryFileTower;
             obj.geometryFileNacelle = data.geometryFileNacelle;
             obj.geometryFileHub = data.geometryFileHub;

--- a/source/objects/windTurbineClass.m
+++ b/source/objects/windTurbineClass.m
@@ -29,6 +29,10 @@ classdef windTurbineClass<handle
         turbineName = '';                                    % Name of file including wind turbine properties  
         roscoName = '';                                      % Name of file for ROSCO properties
         omega0 = [];                                         % Initial rotor speed
+        geometryFileTower = '';                              % Tower geometry file
+        geometryFileNacelle = '';                            % Nacelle geometry file
+        geometryFileHub = '';                                % Hub geometry file
+        geometryFileBlade = '';                              % Blade geometry file
     end
     
     
@@ -44,10 +48,6 @@ classdef windTurbineClass<handle
             'omegaErr',             0, ...                   % Rotor speed difference with steady-state for look-up table
             'V',            [0 0 0]);                        % Wind speed for look-up table    
         generatorEfficiency = [];                            % Generator efficiency
-        geometryFileTower = '';                              % Tower geometry file
-        geometryFileNacelle = '';                            % Nacelle geometry file
-        geometryFileHub = '';                                % Hub geometry file
-        geometryFileBlade = '';                              % Blade geometry file
         tower = struct(...                                   % Tower structure properties
             'mass',     0, ...                               % Mass of tower
             'inertia',             [0 0 0], ...              % Moments of inertia of tower
@@ -120,12 +120,12 @@ classdef windTurbineClass<handle
             obj.geometryFileHub = data.geometryFileHub;
             obj.geometryFileBlade = data.geometryFileBlade;  
             obj.tower.mass = data.tower.mass;
-            obj.tower.inertia = data.tower.inertia;                % Moment of Inertia [kg*m^2]  
+            obj.tower.inertia = data.tower.Inertia;                % Moment of Inertia [kg*m^2]  
             obj.tower.cog_rel = data.tower.cog_rel;    
             obj.tower.height = data.tower.height;
             obj.tower.offset = data.tower.offset;
             obj.nacelle.mass = data.nacelle.mass;
-            obj.nacelle.inertia = data.nacelle.inertia;
+            obj.nacelle.inertia = data.nacelle.Inertia;
             obj.nacelle.Twr2Shft = data.nacelle.Twr2Shft;
             obj.hub.overhang = data.hub.overhang;
             obj.nacelle.mass_yawBearing = data.nacelle.mass_yawBearing;
@@ -133,18 +133,18 @@ classdef windTurbineClass<handle
             obj.nacelle.reference = data.nacelle.reference;
             obj.nacelle.tiltangle = data.nacelle.tiltangle;
             obj.hub.mass = data.hub.mass;
-            obj.hub.inertia = data.hub.inertia;
-            obj.hub.inertiaProducts = data.hub.inertiaProducts;
+            obj.hub.inertia = data.hub.Inertia;
+            obj.hub.inertiaProducts = data.hub.InertiaProduct;
             obj.hub.cog_rel = data.hub.cog_rel;  
             obj.hub.reference = data.hub.reference;
-            obj.hub.hubheight = data.hub.height;
+            obj.hub.height = data.hub.height;
             obj.hub.Rhub = data.hub.Rhub;
             obj.hub.precone = data.hub.precone;
             obj.blade.mass = data.blade.mass;
-            obj.blade.inertia = data.blade.inertia;
-            obj.blade.inertiaProducts = data.blade.inertiaProducts;
+            obj.blade.inertia = data.blade.Inertia;
+            obj.blade.inertiaProducts = data.blade.InertiaProduct;
             obj.blade.cog_rel = data.blade.cog_rel; 
-            obj.blade.bladeDiscr = data.blade.bladeDiscr;
+            obj.blade.bladeDiscr = data.blade.bladediscr;
          end
 
          function setNumber(obj,number)

--- a/source/objects/windturbineClass.m
+++ b/source/objects/windturbineClass.m
@@ -25,9 +25,9 @@ classdef windTurbineClass<handle
     properties (SetAccess = 'public', GetAccess = 'public') %input file
         name              = []                               % (`string`) Specifies the windTurbine name. 
         control = 0;                                         % Type of control: 0-->baseline, 1-->ROSCO   
-        aeroloads_name = '';                                 % Name of aeroloads file       
-        turbine_name = '';                                  % Name of file including wind turbine properties  
-        rosco_name = '';                                     % Name of file for ROSCO properties
+        aeroloadsName = '';                                  % Name of aeroloads file       
+        turbineName = '';                                    % Name of file including wind turbine properties  
+        roscoName = '';                                      % Name of file for ROSCO properties
         omega0 = [];                                         % Initial rotor speed
     end
     
@@ -40,10 +40,10 @@ classdef windTurbineClass<handle
             'MY',             0, ...                         % Bending moments look-up table      
             'SS',             0, ...                         % Steady states
             'ctrl',             0, ...                       % Control parameters for baseline blade pitch control
-            'thetaerr',             0, ...                   % Blade pitch difference with steady-state for look-up table
-            'omegaerr',             0, ...                   % Rotor speed difference with steady-state for look-up table
+            'thetaErr',             0, ...                   % Blade pitch difference with steady-state for look-up table
+            'omegaErr',             0, ...                   % Rotor speed difference with steady-state for look-up table
             'V',            [0 0 0]);                        % Wind speed for look-up table    
-        gen_eff = [];                                        % Generator efficiency
+        generatorEfficiency = [];                            % Generator efficiency
         geometryFileTower = '';                              % Tower geometry file
         geometryFileNacelle = '';                            % Nacelle geometry file
         geometryFileHub = '';                                % Hub geometry file
@@ -51,21 +51,21 @@ classdef windTurbineClass<handle
         tower = struct(...                                   % Tower structure properties
             'mass',     0, ...                               % Mass of tower
             'inertia',             [0 0 0], ...              % Moments of inertia of tower
-            'inertiaProducts',      [0 0 0], ...              % Product of inertia of tower
+            'inertiaProducts',      [0 0 0], ...             % Product of inertia of tower
             'height',             0, ...                     % Height of tower        
             'offset',             0, ...                     % Lower point of tower relative to Sea Water Level
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to tower offset
         nacelle = struct(...                                 % Nacelle structure properties
             'mass',     0, ...                               % Mass of nacelle
             'inertia',             [0 0 0], ...              % Moments of inertia of nacelle
-            'inertiaProducts',      [0 0 0], ...              % Product of inertia of nacelle
+            'inertiaProducts',      [0 0 0], ...             % Product of inertia of nacelle
             'reference',           [0 0 0], ...              % Nacelle reference point for hub
             'tiltangle',           [0 0 0], ...              % Tilt angle of nacelle (deg)
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to tower top
         hub = struct(...                                     % Hub structure properties
             'mass',     0, ...                               % Mass of hub             
             'inertia',             [0 0 0], ...              % Moments of Inertia of hub
-            'inertiaProducts',      [0 0 0], ...              % Product of inertia of hub
+            'inertiaProducts',      [0 0 0], ...             % Product of inertia of hub
             'reference',           [0 0 0], ...              % Hub reference point for blades
             'precone',           [0 0 0], ...                % Hub precone angle (deg)
             'hubheight',           [0 0 0], ...              % Hub height relative to Sea Water Level
@@ -73,8 +73,8 @@ classdef windTurbineClass<handle
         blade = struct(...                                   % Blade structure properties
             'mass',     0, ...                               % Mass of the blade 
             'inertia',             [0 0 0], ...              % Moments of Inertia of the blade  
-            'inertiaProducts',      [0 0 0], ...              % Product of inertia of blade                    
-            'bladediscr',           [0 0 0], ...             % Blade discretisation for wind speed average estimation 
+            'inertiaProducts',      [0 0 0], ...             % Product of inertia of blade                    
+            'bladeDiscr',           [0 0 0], ...             % Blade discretisation for wind speed average estimation 
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to blade root position
          number = [];                                        % Wind turbine number
          ROSCO = struct();                                   % ROSCO parameters
@@ -100,29 +100,32 @@ classdef windTurbineClass<handle
             else
                 error('The windTurbineclass() function should be called first to initialize each wind turbine with a name.')
             end
-         end
+        end
+
          function ImportAeroloadsTable(obj)
-            data = importdata(obj.aeroloads_name);
+            data = importdata(obj.aeroloadsName);
             obj.aeroloads = data;
          end
+
          function Importrosco(obj)
-            data = importdata(obj.rosco_name);
+            data = importdata(obj.roscoName);
             obj.ROSCO = data;
          end
+
          function loadTurbineData(obj)
-            data = importdata(obj.turbine_name); 
-            obj.gen_eff=data.gen_eff; %generator efficiency
+            data = importdata(obj.turbineName); 
+            obj.generatorEfficiency=data.gen_eff; %generator efficiency
             obj.geometryFileTower = data.geometryFileTower;
             obj.geometryFileNacelle = data.geometryFileNacelle;
             obj.geometryFileHub = data.geometryFileHub;
             obj.geometryFileBlade = data.geometryFileBlade;  
             obj.tower.mass = data.tower.mass;
-            obj.tower.Inertia = data.tower.Inertia;                % Moment of Inertia [kg*m^2]  
+            obj.tower.inertia = data.tower.inertia;                % Moment of Inertia [kg*m^2]  
             obj.tower.cog_rel = data.tower.cog_rel;    
             obj.tower.height = data.tower.height;
             obj.tower.offset = data.tower.offset;
             obj.nacelle.mass = data.nacelle.mass;
-            obj.nacelle.Inertia = data.nacelle.Inertia;
+            obj.nacelle.inertia = data.nacelle.inertia;
             obj.nacelle.Twr2Shft = data.nacelle.Twr2Shft;
             obj.hub.overhang = data.hub.overhang;
             obj.nacelle.mass_yawBearing = data.nacelle.mass_yawBearing;
@@ -130,24 +133,23 @@ classdef windTurbineClass<handle
             obj.nacelle.reference = data.nacelle.reference;
             obj.nacelle.tiltangle = data.nacelle.tiltangle;
             obj.hub.mass = data.hub.mass;
-            obj.hub.Inertia = data.hub.Inertia;
-            obj.hub.InertiaProduct = data.hub.InertiaProduct;
+            obj.hub.inertia = data.hub.inertia;
+            obj.hub.inertiaProducts = data.hub.inertiaProducts;
             obj.hub.cog_rel = data.hub.cog_rel;  
             obj.hub.reference = data.hub.reference;
             obj.hub.hubheight = data.hub.height;
             obj.hub.Rhub = data.hub.Rhub;
             obj.hub.precone = data.hub.precone;
             obj.blade.mass = data.blade.mass;
-            obj.blade.Inertia = data.blade.Inertia;
-            obj.blade.InertiaProduct = data.blade.InertiaProduct;
+            obj.blade.inertia = data.blade.inertia;
+            obj.blade.inertiaProducts = data.blade.inertiaProducts;
             obj.blade.cog_rel = data.blade.cog_rel; 
-            obj.blade.bladediscr = data.blade.bladediscr;
+            obj.blade.bladeDiscr = data.blade.bladeDiscr;
          end
+
          function setNumber(obj,number)
             % Method to set the private number property
             obj.number = number;
          end
-               
     end
-     
 end

--- a/source/objects/windturbineClass.m
+++ b/source/objects/windturbineClass.m
@@ -14,16 +14,16 @@
 % limitations under the License.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-classdef windturbineClass<handle
+classdef windTurbineClass<handle
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    % The  ``windturbineClass`` creates a ``wind turbine`` object saved to the MATLAB
+    % The  ``windTurbineClass`` creates a ``wind turbine`` object saved to the MATLAB
     % workspace. 
     %
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     
     
     properties (SetAccess = 'public', GetAccess = 'public') %input file
-        name              = []                               % (`string`) Specifies the windturbine name. 
+        name              = []                               % (`string`) Specifies the windTurbine name. 
         control = 0;                                         % Type of control: 0-->baseline, 1-->ROSCO   
         aeroloads_name = '';                                 % Name of aeroloads file       
         turbine_name = '';                                  % Name of file including wind turbine properties  
@@ -50,30 +50,30 @@ classdef windturbineClass<handle
         geometryFileBlade = '';                              % Blade geometry file
         tower = struct(...                                   % Tower structure properties
             'mass',     0, ...                               % Mass of tower
-            'Inertia',             [0 0 0], ...              % Moments of inertia of tower
-            'InertiaProduct',      [0 0 0], ...              % Product of inertia of tower
+            'inertia',             [0 0 0], ...              % Moments of inertia of tower
+            'inertiaProducts',      [0 0 0], ...              % Product of inertia of tower
             'height',             0, ...                     % Height of tower        
             'offset',             0, ...                     % Lower point of tower relative to Sea Water Level
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to tower offset
         nacelle = struct(...                                 % Nacelle structure properties
             'mass',     0, ...                               % Mass of nacelle
-            'Inertia',             [0 0 0], ...              % Moments of inertia of nacelle
-            'InertiaProduct',      [0 0 0], ...              % Product of inertia of nacelle
+            'inertia',             [0 0 0], ...              % Moments of inertia of nacelle
+            'inertiaProducts',      [0 0 0], ...              % Product of inertia of nacelle
             'reference',           [0 0 0], ...              % Nacelle reference point for hub
             'tiltangle',           [0 0 0], ...              % Tilt angle of nacelle (deg)
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to tower top
         hub = struct(...                                     % Hub structure properties
             'mass',     0, ...                               % Mass of hub             
-            'Inertia',             [0 0 0], ...              % Moments of Inertia of hub
-            'InertiaProduct',      [0 0 0], ...              % Product of inertia of hub
+            'inertia',             [0 0 0], ...              % Moments of Inertia of hub
+            'inertiaProducts',      [0 0 0], ...              % Product of inertia of hub
             'reference',           [0 0 0], ...              % Hub reference point for blades
             'precone',           [0 0 0], ...                % Hub precone angle (deg)
             'hubheight',           [0 0 0], ...              % Hub height relative to Sea Water Level
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to nacelle reference
         blade = struct(...                                   % Blade structure properties
             'mass',     0, ...                               % Mass of the blade 
-            'Inertia',             [0 0 0], ...              % Moments of Inertia of the blade  
-            'InertiaProduct',      [0 0 0], ...              % Product of inertia of blade                    
+            'inertia',             [0 0 0], ...              % Moments of Inertia of the blade  
+            'inertiaProducts',      [0 0 0], ...              % Product of inertia of blade                    
             'bladediscr',           [0 0 0], ...             % Blade discretisation for wind speed average estimation 
             'cog_rel',            [0 0 0]);                  % Center of Gravity relative to blade root position
          number = [];                                        % Wind turbine number
@@ -81,9 +81,9 @@ classdef windturbineClass<handle
     end
     
     methods (Access = 'public')
-        function obj = windturbineClass(name)
-            % This method initilizes the ``windturbineClass`` and creates a
-            % ``windturbine`` object.          
+        function obj = windTurbineClass(name)
+            % This method initilizes the ``windTurbineClass`` and creates a
+            % ``windTurbine`` object.          
             %
             % Parameters
             % ------------
@@ -92,13 +92,13 @@ classdef windturbineClass<handle
             %
             % Returns
             % ------------
-            %     windturbine : obj
-            %         windturbineClass object         
+            %     windTurbine : obj
+            %         windTurbineClass object         
             %
             if exist('name','var')
                 obj.name = name;
             else
-                error('The windturbineclass() function should be called first to initialize each wind turbine with a name.')
+                error('The windTurbineclass() function should be called first to initialize each wind turbine with a name.')
             end
          end
          function ImportAeroloadsTable(obj)


### PR DESCRIPTION
This PR incorporates several suggested updates for the library and windTurbine class, just as PR #3 did for the windClass
- [x] library to R2020b
- [x] refactoring of windTurbine variable naming. Updated to WEC-Sim's camelCase and long variable name conventions
- [x] logic for windClass and windTurbineClass post-processing. Updated to follow convention for other optional WEC-Sim classes
- [x] suggested masking and linking of library blocks. Many blocks have repeated functionality, which can be difficult to update if issues or changes are made in a repeated block. The aerodynamic calculations and blade blocks were masked and linked where possible to mirror each other.
- [x] Moved readTurbSimOutput out of the windClass and into a ``mostIO`` function (similar to BEMIO). 

I have been updating a WEC-Sim+MOST example that will become a WEC-Sim Application [here ](https://github.com/WEC-Sim/WEC-Sim_Applications/pull/36). This application contains the necessary renaming and a ``mostIO`` function that can be used for pre-processing.